### PR TITLE
get post(s)

### DIFF
--- a/collect_social/twitter/api.py
+++ b/collect_social/twitter/api.py
@@ -29,9 +29,18 @@ def map_following(twitter_following):
 
 
 def map_post(twitter_post):
-    # return d4d.Post
-    pass
+    # could be extended/altered in the future
+    return {
+	'id_str': twitter_post.id_str,
+        'user_id': twitter_post.user.id_str,
+        'text': twitter_post.text,
+        'created_at': twitter_post.created_at,
+        'retweet_count': twitter_post.retweet_count,
+        'favorite_count': twitter_post.favorite_count,
+    }
 
+def map_posts(twitter_posts):
+    return [map_post(post) for post in twitter_posts]
 
 def map_comment(twitter_post):
     # return d4d.Comment
@@ -56,14 +65,20 @@ class Twitter(object):
         Params: id
         Returns: dict
         """
-        pass
+        return map_post(self._api.get_status(id))
 
     def get_posts(self, user_id):
         """
-        Params: id[ ]
+        Params: id
         Returns: dict[ ]
         """
-        pass
+	# NOTE: will download all non-retweets of the past 3200 posts 
+	# from user_id
+        posts = []
+	for page in tweepy.Cursor(self._api.user_timeline, id=user_id).pages():
+		posts.extend(page)
+
+	return map_posts(posts)
 
     def get_user(self, handle):
         """

--- a/tests/test_twitter_api.py
+++ b/tests/test_twitter_api.py
@@ -1,11 +1,14 @@
 import pytest
-from collect_social.twitter.api import map_user, map_followers
+from collect_social.twitter.api import map_post, map_user, map_followers
 
 
 class User:
     def __init__(self, **entries):
         self.__dict__.update(entries)
 
+class Status:
+    def __init__(self, **entries):
+        self.__dict__.update(entries)
 
 @pytest.fixture
 def twitter_user():
@@ -29,6 +32,40 @@ def twitter_user():
     user = (User(**user_dict))
     return user
 
+def twitter_status():
+    status_dict = {
+        'id_str': '40977446',
+        'user_id': '78910',
+        'text': 'Hello I am a tweet',
+        'created_at': '2009-05-18 21:48:17.000000',
+        'retweet_count': 5,
+        'favorite_count': 50,
+    }
+
+    user_dict = {
+        'created_at': '2009-05-18 21:48:17.000000',
+        'description': 'Collaborating on data projects to build a stronger society.',
+        'followers_count': 500,
+        'friends_count': 1000,
+        'statuses_count': 3,
+        'id_str': '40977446',
+        'location': 'Washington DC',
+        'time_zone': 'UTC',
+        'lang': 'en',
+        'screen_name': 'data4democracy',
+        'name': 'Data For Democracy',
+        'verified': False,
+        'favourites_count': 0
+
+    }
+
+    
+    status = (Status(**status_dict))
+    status.user = (User(**user_dict))
+    return status
+
+def test_map_post():
+    assert map_post(twitter_status())
 
 def test_map_user():
     assert map_user(twitter_user())


### PR DESCRIPTION
I implemented basic functionality for get_posts (by user_id) and get_post (by tweet ID) in api.py. I only included very barebones info for each tweet at the moment--I can always add more categories, create dicts-within-dicts, etc, if people would like more data. I'd like to eventually align it with whatever is implemented for Facebook. Also note that using get_posts you can only grab any non-retweets from the past 3200 posts by the user; this is a limit placed by Twitter that is unavoidable. 